### PR TITLE
Control Arduino from Raspberry Pi

### DIFF
--- a/GoControl/control.go
+++ b/GoControl/control.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/tarm/serial"
+)
+
+func main() {
+	c := &serial.Config{Name: "/dev/tty.usbmodem1421", Baud: 9600}
+	s, err := serial.OpenPort(c)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = s.Write([]byte{byte(50)})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Wrote a, Waiting for a while")
+	time.Sleep(10 * time.Second)
+
+	_, err = s.Write([]byte{byte(120)})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Wrote Z. Waiting for a while")
+	time.Sleep(3 * time.Second)
+}

--- a/GoControl/control.ino
+++ b/GoControl/control.ino
@@ -1,0 +1,17 @@
+int Delay = 1000;
+
+void setup() {
+  Serial.begin(9600);
+  pinMode(13, OUTPUT);
+}
+
+void loop() {
+  if (Serial.available()) {
+    Delay = Serial.read();
+  }
+  // put your main code here, to run repeatedly:
+  digitalWrite(13, HIGH);
+  delay(Delay);
+  digitalWrite(13, LOW);
+  delay(Delay);
+}


### PR DESCRIPTION
This change includes a Go program, `control.go`, running on Raspberry Pi (or any other platform) that controls the Arduino to flash its LED in various frequency. The control commands are sent through USB cable.
